### PR TITLE
Update spec to use config.json

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -12,9 +12,7 @@ The Engine Docker container is provided the source code to analyze at `/code`, w
 
 * `/code`, a directory containing the files to analyze (read-only)
 
-Engines accept a configuration in JSON format passed as an environment variable named `ENGINE_CONFIG`. Methods for reading an environment variable vary between programming languages, but are typically simple. As an example, in Node.js you would parse the config as follows:
-
-    NODE_SNIPPET_HERE
+Engines accept a configuration in JSON format passed as a read-only file mounted at `/config.json`.
 
 Engines can define their own appropriate configuration keys and values, based on
 their needs. A developer invoking a Code Climate engine stores their configuration


### PR DESCRIPTION
/cc @codeclimate/review @brynary @mrb 

The environment variable file has a go-enforced 64k line limit, which makes larger engine configs (especially with expanded exclude paths) impossible. Thus, after some discussion, we decided to go to using a `/config.json` file which does not have the same limit (and will also let us split the config over lines if need be).

Question: should I include an example on how to read/parse a JSON file in a specific language?