### PR TITLE
Clarify use of null character

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -24,7 +24,7 @@ Certain keys of the config object will be passed to all engines, and must be res
 
 ## Output
 
-Engines stream static analysis Issues to STDOUT in JSON format. When possible, results should be emitted as soon as they are computed (streaming, not buffered). Documents are terminated by the [null character][null] (`\0` in most programming languages), but can additionally be separated by newlines.
+Engines stream static analysis Issues to STDOUT in JSON format. When possible, results should be emitted as soon as they are computed (streaming, not buffered). Each issue is terminated by the [null character][null] (`\0` in most programming languages), but can additionally be separated by newlines.
 
 Unstructured information can be printed on STDERR for the purposes of aiding debugging.
 


### PR DESCRIPTION
It wasn't clear to me whether the null character should come after all the issues, or after each issue. Experimentation showed that it's the latter. Hopefully this change makes it a little more obvious.