### PR TITLE
How to reference the whole file

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -141,9 +141,23 @@ And another:
 }
 ```
 
+In case you want to reference the whole file instead of single lines:
+
+```json
+{
+  "path": "path/to/file.css",
+  "lines": {
+    "begin": 1,
+    "end": 1
+  }
+}
+```
+
 All Locations require a `path` property, which is the file path relative to `/code`.
 
 Locations of the first form (_line-based_ locations) emit a beginning and end line number for the issue, which form a range. Line numbers are 1-based, so the first line of a file would be represented by `1`. Line ranges are evaluated inclusively, so a range of `{"begin": 9, "end": 11}` would represent lines 9, 10 and 11.
+
+If your issue concerns a whole file instead of single lines, pass a beginning and end line number of `1`.
 
 Locations in the second form (_position-based_ locations) allow more precision by including references to the specific characters that form the source code range representing the issue.
 


### PR DESCRIPTION
From the documentation, it's not clear that `lines: { begin: 1, end: 1 }` should be used when referencing the whole file.