### PR TITLE
Add fingerprint documentation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -67,7 +67,8 @@ An `issue` represents a single instance of a real or potential code problem, det
   "location": Location,
   "other_locations": [Location],
   "remediation_points": 500,
-  "severity": Severity
+  "severity": Severity,
+  "fingerprint": "abcd1234"
 }
 ```
 
@@ -80,6 +81,7 @@ An `issue` represents a single instance of a real or potential code problem, det
 * `trace` -- **Optional.** A `Trace` object representing other interesting source code locations related to this issue.
 * `remediation_points` -- **Optional**. An integer indicating a rough estimate of how long it would take to resolve the reported issue.
 * `severity` -- **Optional**. A `Severity` string (`info`, `normal`, or `critical`) describing the potential impact of the issue found.
+* `fingerprint` -- **Optional**. A unique, deterministic identifier for the specific issue being reported to allow a user to exclude it from future analyses.
 
 #### Descriptions
 


### PR DESCRIPTION
When I did a final pass on the Brakeman native integration, I used the spec as a reference for what we should be passing. Unfortunately fingerprint was not documented and was thus omitted from our initial implementation. This at least adds mention of a fingerprint in the example Issue JSON and some explanation about how it is used.

@mrb @brynary 