### PR TITLE
Set example remediation points to a reasonable value

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -66,7 +66,7 @@ An `issue` represents a single instance of a real or potential code problem, det
   "categories": ["Complexity"],
   "location": Location,
   "other_locations": [Location],
-  "remediation_points": 500,
+  "remediation_points": 50000,
   "severity": Severity,
   "fingerprint": "abcd1234"
 }


### PR DESCRIPTION
`500` was absurdly low, according to our own descriptions of points & how we actually use them elsewhere.

This low value being used as an example here has already led to confusion & some engines using inappropriately low values, so I think we should using a semi-sane value.

@codeclimate/review 