### PR TITLE
Move "Data types" section out of "Engine execution" section.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -120,7 +120,7 @@ All engines must include an `engine.json` file at `/engine.json`. This file incl
 }
 ```
 
-The following fields are declared the specification file, and all are required:
+The following fields are declared in the specification file, and all are required:
 
 * `name` (`String`) - the name of the package
 * `description` (`String`) - a description of the engine


### PR DESCRIPTION
@brynary This is another cleanup that does not change the meaning of the spec. Since we're going to start reference data types from places other than engine execution, we should break out "Data types" into its own standalone section.